### PR TITLE
Implement check to prevent negative-numbers

### DIFF
--- a/src/main/java/life/nekos/bot/commands/user/ReleaseCommand.java
+++ b/src/main/java/life/nekos/bot/commands/user/ReleaseCommand.java
@@ -13,12 +13,16 @@ import net.dv8tion.jda.core.entities.Message;
         triggers = {"release", "free", "catch"},
         attributes = {@CommandAttribute(key = "user")},
         description =
-                "Releases one of your nekos for others to catch  >.< (you cant not catch a neko you relesaed)"
+                "Releases one of your nekos for others to catch  >.< (you can not catch a neko you relesaed)"
 )
 public class ReleaseCommand implements Command {
     @Override
     public void execute(Message message, String args) {
         Models.statsUp("release");
+        if(Models.getBal(message.getAuthor().getId()) == 0){
+                message.getChannel().sendMessage("Nya~ You do not have any nekos to release nya~").queue();
+                return;
+        }
         Models.setBal(message.getAuthor().getId(), Models.getBal(message.getAuthor().getId()) - 1);
         SendNeko.send(message, true);
         if (BotChecks.canDelete(message)) {


### PR DESCRIPTION
Users are able to release nekos, even if they have 0 at the moment.
This *should* fix this issue by simply adding a check for `getBal` to check, how many nekos they have and if they have 0 or not.

Check of the code is required.