### PR TITLE
Fixing issue with Discords new Spoiler-function

### DIFF
--- a/src/main/java/life/nekos/bot/commands/audio/PlayCommand.java
+++ b/src/main/java/life/nekos/bot/commands/audio/PlayCommand.java
@@ -19,7 +19,7 @@ import java.text.MessageFormat;
         name = "play",
         triggers = {"play", "p"},
         attributes = {@CommandAttribute(key = "music"), @CommandAttribute(key = "dm")},
-        description = "play some url || search term"
+        description = "play some url | search term"
 )
 public class PlayCommand implements Command {
     public void execute(Message message, String args) {

--- a/src/main/java/life/nekos/bot/commands/audio/PlaylistCommand.java
+++ b/src/main/java/life/nekos/bot/commands/audio/PlaylistCommand.java
@@ -16,7 +16,7 @@ import java.text.MessageFormat;
         name = "playlist",
         triggers = {"playlist", "pl"},
         attributes = {@CommandAttribute(key = "music"), @CommandAttribute(key = "dm")},
-        description = "play some playlist url || search term"
+        description = "play some playlist url | search term"
 )
 public class PlaylistCommand implements Command {
     public void execute(Message event, String args) {

--- a/src/main/java/life/nekos/bot/commands/neko/SildeShowCommand.java
+++ b/src/main/java/life/nekos/bot/commands/neko/SildeShowCommand.java
@@ -31,7 +31,7 @@ public class SildeShowCommand implements Command {
         if (!canDelete(event)) {
             event
                     .getTextChannel()
-                    .sendMessage(Formats.error("You lack the `manage_messgaes` permission"))
+                    .sendMessage(Formats.error("I lack the `manage_messgaes` permission"))
                     .queue();
             return;
 


### PR DESCRIPTION
This PR removes one pipe (`|`) from the descriptions of the `~play` and the `~playlist` command, which caused Discord to put the text between those two characters, to be covered as spoiler (see image)

Image:
![image](https://user-images.githubusercontent.com/11576465/52128394-278a2d80-2635-11e9-8f1a-b3668e1b8417.png)
