### PR TITLE
Add fix for if message is from bot

### DIFF
--- a/src/main/java/life/nekos/bot/commons/SendNeko.java
+++ b/src/main/java/life/nekos/bot/commons/SendNeko.java
@@ -72,7 +72,7 @@ public class SendNeko {
 								waiter.waitForEvent(
 										MessageReceivedEvent.class,
 										e ->
-												(!sent || e.getAuthor() != event.getAuthor())
+												(!sent || (e.getAuthor() != event.getAuthor()) || !e.getAuthor().isBot())
 														&& isMatch(e.getMessage().getContentRaw().toLowerCase(), catchStr)
 														&& e.getTextChannel().equals(event.getTextChannel()),
 										e -> {


### PR DESCRIPTION
Bots are able to catch wild nekos, even when that isn't supposed to happen.
This should fix it.

![](https://cdn.discordapp.com/attachments/420348740511989761/557521045968519168/unknown.png)